### PR TITLE
Implement Server Monitor API Routes

### DIFF
--- a/wrapper/src/lib/api/serverMonitors.ts
+++ b/wrapper/src/lib/api/serverMonitors.ts
@@ -1,0 +1,37 @@
+import { ServerMonitor, NewServerMonitor } from '../../types/serverMonitors'
+import { API_BASEURL } from "../../util/constants"
+import axiosInstance from "../axiosInstance"
+import type { AxiosError } from "axios"
+import { invalidApiResponseStack } from "../../util/invalidApiResponseStack"
+
+export const createServerMonitorController = () => {
+  return {
+    create(serverMonitor: NewServerMonitor): Promise<void> {
+      return new Promise(async (resolve, reject) => {
+        await axiosInstance.post(`${API_BASEURL}/monitors/servers`, serverMonitor)
+          .then(() => {
+            return resolve();
+          }).catch((err: AxiosError) => {
+            let timestamp = err.response?.data.meta.timestamp;
+
+            if (!timestamp) return reject([invalidApiResponseStack]);
+            return reject(err.response);
+          })
+      });
+    },
+
+    list(): Promise<ServerMonitor[]> {
+      return new Promise(async (resolve, reject) => {
+        await axiosInstance.get(`${API_BASEURL}/monitors/servers`)
+          .then((res) => {
+            return resolve(res.data.data)
+          }).catch((err: AxiosError) => {
+            let timestamp = err.response?.data.meta.timestamp
+
+            if (!timestamp) return reject([invalidApiResponseStack])
+            return reject(err.response)
+          })
+      })
+    }
+  }
+}

--- a/wrapper/src/types/serverMonitors.ts
+++ b/wrapper/src/types/serverMonitors.ts
@@ -1,0 +1,12 @@
+export interface ServerMonitor {
+  id: string;
+  name: string;
+  creatorId: string;
+  collectionId: string;
+}
+
+export interface NewServerMonitor {
+  name: string;
+  creatorId: string;
+  collectionId: string;
+}

--- a/wrapper/src/types/serverMonitors.ts
+++ b/wrapper/src/types/serverMonitors.ts
@@ -7,6 +7,5 @@ export interface ServerMonitor {
 
 export interface NewServerMonitor {
   name: string;
-  creatorId: string;
   collectionId: string;
 }

--- a/wrapper/src/types/serviceCollections.ts
+++ b/wrapper/src/types/serviceCollections.ts
@@ -1,3 +1,5 @@
+import { ServerMonitor } from "./serverMonitors"
+
 export interface NewCollection {
   name: string
 }
@@ -8,4 +10,5 @@ export interface Collection {
   creator: string
   created: string
   lastUpdated: string
+  monitors: ServerMonitor[]
 }


### PR DESCRIPTION
Wrapper updates.

- Implements `GET` and `POST` to `monitors/servers`.
- Updates `GET` for `services/collections`.

Fixes #46 
