### PR TITLE
Fix core deployment on Linux

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     build: ./
     restart: always
     environment:
-      - MASTER_SERVER=ws://host.docker.internal:49758
-      - DATABASE_URL=postgres://duxcore:123web123@host.docker.internal/duxcore
+      - MASTER_SERVER=ws://172.17.0.1:49758
+      - DATABASE_URL=postgres://duxcore:123web123@172.17.0.1/duxcore
 
   nginx:
     image: nginx:latest

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: ./
     restart: always
     environment:
-      - MASTER_SERVER=ws://172.17.0.1:49758
+      - MASTER_SERVER=ws://127.0.0.1:49758
       - DATABASE_URL=postgres://duxcore:123web123@172.17.0.1/duxcore
 
   nginx:


### PR DESCRIPTION
As this PR currently stands, as long as everything is deployed to the same docker instance (and hence network) this should work.
We still need a way to deploy the master to docker, or to allow requests to the host where the master is running.

Looking for feedback on this, to see if it fixes the original issue, and how to solve the issue with the master not being accessible from inside docker.